### PR TITLE
Adding deprecation notice to the card expiry notification option

### DIFF
--- a/css/foxyshop-admin.css
+++ b/css/foxyshop-admin.css
@@ -961,6 +961,19 @@ table.cfbe_foxyshop_table .chzn-container {
     margin: 5px 0;
 }
 
+.foxyshop-notice {
+    float:left;
+    clear:both;
+    border-left-width: 4px;
+    border-left-style: solid;
+    box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
+    margin: 10px 0px 15px;
+    padding: 8px 12px;
+}
+.foxyshop-notice *:last-child {
+    margin-bottom:0;
+}
+
 
 /* Responsive Variations */
 @media all and (max-width: 1150px) {

--- a/settings-page.php
+++ b/settings-page.php
@@ -467,11 +467,16 @@ function foxyshop_settings_page() {
 					<input type="checkbox" id="foxyshop_enable_subscriptions" name="foxyshop_enable_subscriptions"<?php checked($foxyshop_settings['enable_subscriptions'], "on"); ?> />
 					<label for="foxyshop_enable_subscriptions"><?php _e('Enable Subscriptions', 'foxyshop'); ?></label>
 					<a href="#" class="foxyshophelp">Show fields to allow the creation of subscription <?php echo strtolower(FOXYSHOP_PRODUCT_NAME_PLURAL); ?>.</a>
+					<?php if ($foxyshop_settings['expiring_cards_reminder']) { ?>
 					<div class="settings_indent">
 						<input type="checkbox" id="foxyshop_expiring_cards_reminder" name="foxyshop_expiring_cards_reminder"<?php checked($foxyshop_settings['expiring_cards_reminder'], "on"); ?> />
 						<label for="foxyshop_expiring_cards_reminder"><?php _e('Send Reminders to Subscription Customers with Expiring Credit Cards', 'foxyshop'); ?></label>
 						<a href="#" class="foxyshophelp"><?php _e('This can be configured in your datafeed template file', 'foxyshop'); ?></a>
+						<div class="foxyshop-notice notice-warning notice-alt">
+							<p><strong>Deprecation Warning:</strong> This feature is <a href="https://wiki.foxycart.com/v/2.0/products/subscriptions#using_foxycart_s_native_dunning_functionality" target="_blank">now part of FoxyCart</a> and will be removed in a future version of FoxyShop. Please disable this option, and instead enable the "expiring soon payment method email schedule" found on the <a href="https://admin.foxycart.com/admin.php?ThisAction=EditAdvancedFeatures" target="_blank">"advanced" page of the Foxy administration</a>.</p>
+						</div>
 					</div>
+					<?php } ?>
 				</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
This PR adds a deprecation notice to the card expiry notification option on the settings page. It piggy backs a little on the normal warning styles of the WP admin, adding a custom class for FoxyShop as WordPress pulls those notices up to the top of the page.

It also hides the option completely if it's not already checked.

We'll remove that functionality completely in a future version.

Relates to #11 
