### PR TITLE
Initial a11y improvements

### DIFF
--- a/css/foxyshop.css
+++ b/css/foxyshop.css
@@ -14,8 +14,8 @@ http://www.foxy-shop.com/documentation/theme-customization/
 
 /* Breadcrumbs Colors */
 #foxyshop_breadcrumbs {
-	background-color: #FBEEB2;
-	border: 1px solid #E3CD69;
+	background-color: #FFF5C9;
+	border: 1px solid #ECDC93;
 }
 
 /* border color for images */
@@ -61,6 +61,9 @@ http://www.foxy-shop.com/documentation/theme-customization/
 	font-family: Arial;
 	font-size: 12px;
 }
+.foxyshop_button:visited {
+	color: #fff;
+}
 .foxyshop_button:hover {
 	background-color: #591b62;
 	color: #fff;
@@ -94,7 +97,7 @@ http://www.foxy-shop.com/documentation/theme-customization/
 }
 .foxyshop_slideshow_title {
 	font-size: 11px;
-	color: #ABABAB;
+	color: #555555;
 }
 .foxyshop_slideshow li img {
 	border: 1px solid #7D268A;
@@ -105,8 +108,8 @@ http://www.foxy-shop.com/documentation/theme-customization/
 
 /* featured product settings */
 .foxyshop_featured_product_list .foxyshop_product_box {
-	background-color: #FBEEB2;
-	border: 1px solid #E3CD69;
+	background-color: #FFF5C9;
+	border: 1px solid #ECDC93;
 }
 
 /* related product settings (gray default) */
@@ -129,8 +132,8 @@ http://www.foxy-shop.com/documentation/theme-customization/
 
 /* Inventory Colors and Settings */
 .foxyshop_stock_alert {
-	background-color: #FBEEB2;
-	border: 1px solid #E3CD69;
+	background-color: #FFF5C9;
+	border: 1px solid #ECDC93;
 	padding: 10px;
 	margin-bottom: 20px;
 }
@@ -145,7 +148,7 @@ http://www.foxy-shop.com/documentation/theme-customization/
 
 
 /* generic settings below */
-#foxyshop_container .clr, .foxyshop_category_widget .clr { clear: both; height: 1px; }
+#foxyshop_container .clr, .foxyshop_container .clr, .foxyshop_category_widget .clr { clear: both; height: 1px; }
 
 
 
@@ -160,6 +163,9 @@ http://www.foxy-shop.com/documentation/theme-customization/
 	float: left;
 	margin: 0 10px 0 0;
 	list-style: none;
+}
+#foxyshop_breadcrumbs a {
+	color:#4F4F4F;
 }
 
 

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -381,7 +381,6 @@ function foxyshop_product_variations($showQuantity = 0, $showPriceVariations = t
 			$variationName = substr($variationName, strpos($variationName,"{")+1, strpos($variationName,"}") - (strpos($variationName,"{")+1));
 		}
 
-
 		$className = "variation-" . sanitize_title_with_dashes($variationName);
 		$writeBeforeVariation = $beforeVariation ? str_replace("%c", $className, $beforeVariation) . "\n" : "";
 		$writeAfterVariation = $afterVariation ? $afterVariation . "\n" : "";
@@ -439,8 +438,8 @@ function foxyshop_product_variations($showQuantity = 0, $showPriceVariations = t
 			//Radio Buttons
 			} elseif ($variationType == "radio") {
 				$write .= $writeBeforeVariation;
-				$write .= '<div class="foxyshop_radio_wrapper">';
-				$write .= '<div class="foxyshop_radio_title' . $dkeyclass . '"'. $dkey . '>' . str_replace("_", " ", $variationDisplayName) . '</div>';
+				$write .= '<div role="radiogroup" aria-labelledby="' . esc_attr($product['code']) . '_' . $i . '" class="foxyshop_radio_wrapper">';
+				$write .= '<div id="' . esc_attr($product['code']) . '_' . $i . '" class="foxyshop_radio_title' . $dkeyclass . '"'. $dkey . '>' . str_replace("_", " ", $variationDisplayName) . '</div>';
 				$write .= foxyshop_run_variations($variationValue, $variationName, $showPriceVariations, $variationType, $dkey, $dkeyclass, $i, $className);
 				$write .= '</div>';
 				$write .= $writeAfterVariation;
@@ -640,9 +639,9 @@ function foxyshop_quantity($qty = 1, $beforeVariation = "", $afterVariation = '<
 	$write .= '<label class="foxyshop_quantity" for="quantity_' . $product['id'] . '">' . $quantity_title . '</label>'."\n";
 	if ($product['quantity_max_original'] > 0) {
 		if ($numberPrefix) {
-			$write .= '<select class="foxyshop_quantity foxyshop_addon_fields" originalname="quantity"  name="x:quantity" rel="' . $numberPrefix . '">';
+			$write .= '<select class="foxyshop_quantity foxyshop_addon_fields" originalname="quantity" name="x:quantity" rel="' . $numberPrefix . '" id="quantity_' . $product['id'] . '">';
 		} else {
-			$write .= '<select class="foxyshop_quantity" name="quantity">';
+			$write .= '<select class="foxyshop_quantity" name="quantity" id="quantity_' . $product['id'] . '">';
 		}
 		for ($i=($product['quantity_min'] > 0 ? $product['quantity_min'] : 1); $i <= $product['quantity_max_original']; $i++) {
 			$write .= '<option value="' . $i . foxyshop_get_verification('quantity',$i) . '">' . $i . '</option>'."\n";
@@ -843,7 +842,7 @@ function foxyshop_build_image_slideshow($slideshow_type = "prettyPhoto", $use_in
 		echo '<div class="foxyshop_product_image_holder">'."\n";
 
 		if ($use_link) echo '<a href="' . foxyshop_get_main_image('large') . '" rel="foxyshop_gallery' . ($imagecount > 1 ? '[' . $product['id'] . ']' : '') . '"  title="' . esc_attr(apply_filters('foxyshop_image_link_title', '')) . '">';
-		echo '<img src="' . foxyshop_get_main_image('medium') . '" id="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image('title')) . '" title="" />';
+		echo '<img src="' . foxyshop_get_main_image('medium') . '" class="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image('title')) . '" title="" />';
 		if ($use_link) echo "</a>\n";
 
 		echo "</div>\n";
@@ -898,7 +897,7 @@ function foxyshop_build_image_slideshow($slideshow_type = "prettyPhoto", $use_in
 		echo '<div class="foxyshop_product_image_holder magnific-gallery">'."\n";
 
 		if ($use_link) echo '<a href="' . foxyshop_get_main_image('large') . '" rel="foxyshop_gallery' . ($imagecount > 1 ? '[' . $product['id'] . ']' : '') . '"  title="' . esc_attr(foxyshop_get_main_image('title')) . '">';
-		echo '<img src="' . foxyshop_get_main_image('medium') . '" id="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image('title')) . '" title="" />';
+		echo '<img src="' . foxyshop_get_main_image('medium') . '" class="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image('title')) . '" title="" />';
 		if ($use_link) echo "</a>\n";
 
 		echo "</div>\n";
@@ -930,7 +929,7 @@ function foxyshop_build_image_slideshow($slideshow_type = "prettyPhoto", $use_in
 		echo '<div class="foxyshop_product_image_holder">'."\n";
 
 		if ($use_link) echo '<a href="' . foxyshop_get_main_image('large') . '" rel="foxyshop_gallery' . ($imagecount > 1 ? '[' . $product['id'] . ']' : '') . '"  title="' . esc_attr(apply_filters('foxyshop_image_link_title', '')) . '">';
-		echo '<img src="' . foxyshop_get_main_image('medium') . '" id="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image('title')) . '" title="" />';
+		echo '<img src="' . foxyshop_get_main_image('medium') . '" class="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image('title')) . '" title="" />';
 		if ($use_link) echo "</a>\n";
 
 		echo "</div>\n";
@@ -960,7 +959,7 @@ function foxyshop_build_image_slideshow($slideshow_type = "prettyPhoto", $use_in
 		echo '<div class="foxyshop_product_image_holder">'."\n";
 
 		if ($use_link) echo '<a href="' . foxyshop_get_main_image("full") . '" id="foxyshop_main_product_image_link_' . $product['id'] . '" class="cloud-zoom" rel="adjustX: 10, adjustY:-4"  title="' . esc_attr(apply_filters('foxyshop_image_link_title', '')) . '">';
-		echo '<img src="' . foxyshop_get_main_image("medium") . '" id="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image("title")) . '" title="" />';
+		echo '<img src="' . foxyshop_get_main_image("medium") . '" class="foxyshop_main_product_image" alt="' . esc_attr(foxyshop_get_main_image("title")) . '" title="" />';
 		if ($use_link) echo "</a>\n";
 
 		echo "</div>\n";
@@ -1192,7 +1191,7 @@ function foxyshop_breadcrumbs($sep = " &raquo; ", $product_fallback = "&laquo; B
 				$url = get_term_link($terminfo, "foxyshop_categories");
 				$write1 .= '<li class="foxyshop_breadcrumb_' . $terminfo->term_id . '"><a href="' . $url . '">' . str_replace("_","",$terminfo->name) . '</a></li>';
 			} else {
-				$write1 .= '<li class="foxyshop_breadcrumb_' . $terminfo->term_id . ' foxyshop_breadcrumb_current">' . str_replace("_","",$terminfo->name) . '</li>';
+				$write1 .= '<li class="foxyshop_breadcrumb_' . $terminfo->term_id . ' foxyshop_breadcrumb_current" aria-current="page">' . str_replace("_","",$terminfo->name) . '</li>';
 			}
 		}
 		//Put product at end if this is a product page
@@ -1201,11 +1200,11 @@ function foxyshop_breadcrumbs($sep = " &raquo; ", $product_fallback = "&laquo; B
 			$write1 .= '<li>'.$post->post_title.'</li>';
 		}
 
-		if ($write1) echo '<ul id="foxyshop_breadcrumbs">' . $write1 . apply_filters('foxyshop_breadcrumb_nofloat', '<li style="float: none; text-indent: -99999px; width: 1px; margin: 0;">-</li>') . '</ul>';
+		if ($write1) echo '<ul id="foxyshop_breadcrumbs" aria-label="Breadcrumb">' . $write1 . apply_filters('foxyshop_breadcrumb_nofloat', '<li style="float: none; text-indent: -99999px; width: 1px; margin: 0;">-</li>') . '</ul>';
 
 	//Product Fallback
 	} elseif ($post->ID && $product_fallback != "") {
-		echo '<ul id="foxyshop_breadcrumbs"><li><a href="' . get_bloginfo('url') . FOXYSHOP_URL_BASE . '/' . apply_filters('foxyshop_template_redirect_product_slug', FOXYSHOP_PRODUCTS_SLUG) . '/">'. $product_fallback . '</a></li>' . apply_filters('foxyshop_breadcrumb_nofloat', '<li style="float: none; text-indent: -99999px; width: 1px; margin: 0;">-</li>') . '</ul>';
+		echo '<ul id="foxyshop_breadcrumbs" aria-label="Breadcrumb"><li><a href="' . get_bloginfo('url') . FOXYSHOP_URL_BASE . '/' . apply_filters('foxyshop_template_redirect_product_slug', FOXYSHOP_PRODUCTS_SLUG) . '/">'. $product_fallback . '</a></li>' . apply_filters('foxyshop_breadcrumb_nofloat', '<li style="float: none; text-indent: -99999px; width: 1px; margin: 0;">-</li>') . '</ul>';
 	}
 
 }
@@ -1241,7 +1240,7 @@ function foxyshop_inventory_management($alertMessage = "There are %c of these it
 	}
 	if ($stockStatus == -1 && !$allowBackOrder) {
 		echo 'jQuery(document).ready(function($){'."\n";
-		echo '$("#foxyshop_product_form_' . $product['id'] . ' #productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");'."\n";
+		echo '$("#foxyshop_product_form_' . $product['id'] . ' .productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");'."\n";
 		echo '});'."\n";
 	}
 	echo '</script>'."\n";

--- a/js/variation.process.jquery.js
+++ b/js/variation.process.jquery.js
@@ -143,7 +143,7 @@ jQuery(document).ready(function($){
 			//Plugin Function Here
 			if (typeof window.foxyshop_before_image_change == 'function') foxyshop_before_image_change(new_ikey);
 
-			$(parentForm + " #foxyshop_main_product_image").attr("src",ikey[new_ikey][2]).attr("alt",ikey[new_ikey][4]).parent().attr("href",ikey[new_ikey][3]);
+			$(parentForm + " .foxyshop_main_product_image").attr("src",ikey[new_ikey][2]).attr("alt",ikey[new_ikey][4]).parent().attr("href",ikey[new_ikey][3]);
 
 			//Cloud-zoom
 			if (typeof window.foxyshop_cloudzoom_image_change == 'function') {
@@ -184,20 +184,20 @@ jQuery(document).ready(function($){
 				$("#fs_quantity_max_" + current_product_id).remove();
 			}
 			if (newcount > 0 && newcount <= newalert) {
-				$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_alert[current_product_id],newcount,inventory_code)).show();
-				$(parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+				$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_alert[current_product_id],newcount,inventory_code,$('#fs_name_' + current_product_id).val())).show();
+				$(parentForm + " .productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 			} else if (newcount <= 0) {
-				$(parentForm + " .foxyshop_stock_alert").addClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_none[current_product_id],inventory_match_count,inventory_code)).show();
-				if (!foxyshop_allow_backorder) $(parentForm + " #productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");
+				$(parentForm + " .foxyshop_stock_alert").addClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_none[current_product_id],inventory_match_count,inventory_code,$('#fs_name_' + current_product_id).val())).show();
+				if (!foxyshop_allow_backorder) $(parentForm + " .productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");
 			} else {
-				$(parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+				$(parentForm + " .productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 				$(parentForm + " .foxyshop_stock_alert").hide();
 			}
 		} else if (typeof arr_foxyshop_inventory[current_product_id] != 'undefined') {
 			if (!foxyshop_allow_backorder) {
 				$("#fs_quantity_max_" + current_product_id).val($("#original_quantity_max_" + current_product_id).val());
 			}
-			$(parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+			$(parentForm + " .productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 			$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").hide();
 		}
 
@@ -228,15 +228,15 @@ jQuery(document).ready(function($){
 		n_sep_by_space = arrl18n_settings[4];
 		new_price += addOnTotal;
 		new_price_original += addOnTotal;
-		$(parentForm + " #foxyshop_main_price .foxyshop_currentprice").text(toCurrency(new_price, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
-		$(parentForm + " #foxyshop_main_price .foxyshop_oldprice").text(toCurrency(new_price_original, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
+		$(parentForm + " .foxyshop_main_price .foxyshop_currentprice").text(toCurrency(new_price, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
+		$(parentForm + " .foxyshop_main_price .foxyshop_oldprice").text(toCurrency(new_price_original, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
 
 		//Plugin Function Here - AFTER CHANGE VARIATIONS
 		if (typeof window.foxyshop_after_variation_modifiers == 'function') foxyshop_after_variation_modifiers(new_code, new_codeadd, new_price, new_price_original, new_ikey, current_product_id);
 
 	}
 
-	function update_inventory_alert_language(strlang, itemcount, itemcode) {
+	function update_inventory_alert_language(strlang, itemcount, itemcode, itemname) {
 		strlang = strlang.replace('%code',itemcode);
 		strlang = strlang.replace('%c',itemcount);
 		if (itemcount == 1) {
@@ -244,7 +244,8 @@ jQuery(document).ready(function($){
 		} else {
 			strlang = strlang.replace('%s',"s");
 		}
-		strlang = strlang.replace('%n',$("#input[name^='name||']").val());
+		itemname = itemname || "";
+		strlang = strlang.replace('%n',itemname);
 		return strlang;
 	}
 
@@ -298,7 +299,7 @@ jQuery(document).ready(function($){
 			e.stopPropagation();
 			e.preventDefault();
 		} else {
-			if (jQuery("#foxyshop_product_form_" + current_product_id + " #productsubmit").attr("disabled")) return false;
+			if (jQuery("#foxyshop_product_form_" + current_product_id + " .productsubmit").attr("disabled")) return false;
 			return true;
 		}
 

--- a/themefiles/foxyshop-all-categories.php
+++ b/themefiles/foxyshop-all-categories.php
@@ -8,7 +8,7 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 <?php get_header(); ?>
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 	<?php
 
 	//echo '<h1 id="foxyshop_category_title">Products</h1>';

--- a/themefiles/foxyshop-all-products.php
+++ b/themefiles/foxyshop-all-products.php
@@ -12,7 +12,7 @@ global $product;
 ?>
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 	<?php
 	//Write Category Title
 	echo '<h1 id="foxyshop_category_title">Products</h1>'."\n";

--- a/themefiles/foxyshop-checkout-template-2.php
+++ b/themefiles/foxyshop-checkout-template-2.php
@@ -60,7 +60,7 @@ get_header(); ?>
 {% include 'svg.inc.twig' %}
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 
 
 {% import "utils.inc.twig" as utils %}

--- a/themefiles/foxyshop-checkout-template.php
+++ b/themefiles/foxyshop-checkout-template.php
@@ -50,7 +50,7 @@ body {
 
 get_header(); ?>
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 
 
 <?php if (version_compare($foxyshop_settings['version'], '1.1', "<=")) { ?>

--- a/themefiles/foxyshop-receipt-template-2.php
+++ b/themefiles/foxyshop-receipt-template-2.php
@@ -61,7 +61,7 @@ get_header(); ?>
 {% include 'svg.inc.twig' %}
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 
 
 {% import "utils.inc.twig" as utils %}

--- a/themefiles/foxyshop-receipt-template.php
+++ b/themefiles/foxyshop-receipt-template.php
@@ -53,7 +53,7 @@ body {
 
 <?php get_header(); ?>
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 
 
 

--- a/themefiles/foxyshop-search.php
+++ b/themefiles/foxyshop-search.php
@@ -8,7 +8,7 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 <?php get_header(); ?>
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 	<h1 id="foxyshop_category_title">Product Search</h1>
 
 	<form class="searchform" action="<?php bloginfo("url"); ?>/product-search/" method="get">
@@ -28,13 +28,13 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 	echo '<ul class="foxyshop_product_list">';
 	while (have_posts()) :
 		the_post();
-		
+
 		//Product Display
 		foxyshop_include('product-loop');
 
 	endwhile;
 	echo '</ul>';
-	
+
 	//Pagination
 	foxyshop_get_pagination();
 	?>

--- a/themefiles/foxyshop-single-category-shortcode.php
+++ b/themefiles/foxyshop-single-category-shortcode.php
@@ -8,7 +8,7 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 global $product, $foxyshop_category_slug, $post;
 ?>
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 	<?php
 	//-------------------------------------------------------------------------------------------------
 	// Remember that the products on these category pages link to the generated page links (permalinks)

--- a/themefiles/foxyshop-single-category.php
+++ b/themefiles/foxyshop-single-category.php
@@ -8,7 +8,7 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 <?php get_header(); ?>
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 	<?php
 	global $product;
 

--- a/themefiles/foxyshop-single-product-shortcode.php
+++ b/themefiles/foxyshop-single-product-shortcode.php
@@ -6,28 +6,28 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 */ ?>
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 <?php
 global $foxyshop_prettyphoto_included;
-	
+
 	//Initialize Product
 	global $product, $prod;
 	$product = foxyshop_setup_product($prod);
-	
+
 	//Just for the widget, since url links are no longer available
 	global $foxyshop_skip_url_link;
 	$foxyshop_skip_url_link = 1;
-	
+
 	//This is for testing to see what is included in the $product array
 	//print_r($product);
-	
+
 	//Initialize Form
 	foxyshop_start_form();
-	
-	
+
+
 	//Write Breadcrumbs
 	//foxyshop_breadcrumbs(" &raquo; ", "&laquo; Back to Products");
-	
+
 
 	//Shows Main Image and Optional Slideshow
 	//Available Built-in Options: magnific-popup (lightbox), prettyPhoto (lightbox)
@@ -41,20 +41,20 @@ global $foxyshop_prettyphoto_included;
 	//Main Product Information Area
 	echo '<div class="foxyshop_product_info">';
 	echo '<h2>' . apply_filters('the_title', $product['name']) . '</h2>';
-	
+
 	//Show a sale tag if the product is on sale
 	//if (foxyshop_is_on_sale()) echo '<p>SALE!</p>';
 
 	//Product Is New Tag (number of days since added)
 	//if (foxyshop_is_product_new(14)) echo '<p>NEW!</p>';
-	
+
 	//Main Product Description
 	echo $product['description'];
 
 
 	//Show Variations (showQuantity: 0 = Do Not Show Qty, 1 = Show Before Variations, 2 = Show Below Variations)
 	foxyshop_product_variations(2);
-	
+
 	//(style) clear floats before the submit button
 	echo '<div class="clr"></div>';
 
@@ -63,12 +63,12 @@ global $foxyshop_prettyphoto_included;
 
 	//Add On Products ($qty, $before_entry, $after_entry)
 	foxyshop_addon_products(true);
-	
+
 	//Add To Cart Button
-	echo '<button type="submit" name="x:productsubmit" id="productsubmit" class="foxyshop_button">Add To Cart</button>';
-	
+	echo '<button type="submit" name="x:productsubmit" class="productsubmit foxyshop_button">Add To Cart</button>';
+
 	//Shows the Price (includes sale price if applicable)
-	echo '<div id="foxyshop_main_price">';
+	echo '<div class="foxyshop_main_price">';
 	foxyshop_price();
 	echo '</div>';
 

--- a/themefiles/foxyshop-single-product.php
+++ b/themefiles/foxyshop-single-product.php
@@ -8,7 +8,7 @@ This will allow you to upgrade FoxyShop without breaking your customizations. Mo
 <?php get_header(); ?>
 
 <?php foxyshop_include('header'); ?>
-<div id="foxyshop_container">
+<div class="foxyshop_container">
 <?php
 while (have_posts()) : the_post();
 
@@ -65,10 +65,10 @@ while (have_posts()) : the_post();
 	foxyshop_addon_products();
 
 	//Add To Cart Button
-	echo '<button type="submit" name="x:productsubmit" id="productsubmit" class="foxyshop_button">Add To Cart</button>';
+	echo '<button type="submit" name="x:productsubmit" class="productsubmit foxyshop_button">Add To Cart</button>';
 
 	//Shows the Price (includes sale price if applicable)
-	echo '<div id="foxyshop_main_price">';
+	echo '<div class="foxyshop_main_price">';
 	foxyshop_price();
 	echo '</div>';
 


### PR DESCRIPTION
This PR includes a number of minor changes to improve a11y support in FoxyShop:

* Switching some ID's to classes to remove potential for duplicate ID's if using shortcodes
    * `foxyshop_container`, `productsubmit`, `foxyshop_main_price`, `foxyshop_main_product_image`
* Updating some styles to improve contrast
* Adding unique ID to select quantity dropdown, as it is for the quantity input
* Adding `radiogroup` role and `aria-labelledby` to radio group variations
* Fixes a bug with `update_inventory_alert_language()` that wasn't correctly updating the name, it now passes the name in as an additional argument