### PR TITLE
Set backward compatibility for some element changes

### DIFF
--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -1240,7 +1240,7 @@ function foxyshop_inventory_management($alertMessage = "There are %c of these it
 	}
 	if ($stockStatus == -1 && !$allowBackOrder) {
 		echo 'jQuery(document).ready(function($){'."\n";
-		echo '$("#foxyshop_product_form_' . $product['id'] . ' .productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");'."\n";
+		echo '$("#foxyshop_product_form_' . $product['id'] . ' .productsubmit", "#foxyshop_product_form_' . $product['id'] . ' #productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");'."\n";
 		echo '});'."\n";
 	}
 	echo '</script>'."\n";

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -1240,7 +1240,7 @@ function foxyshop_inventory_management($alertMessage = "There are %c of these it
 	}
 	if ($stockStatus == -1 && !$allowBackOrder) {
 		echo 'jQuery(document).ready(function($){'."\n";
-		echo '$("#foxyshop_product_form_' . $product['id'] . ' .productsubmit", "#foxyshop_product_form_' . $product['id'] . ' #productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");'."\n";
+		echo '$("#foxyshop_product_form_' . $product['id'] . ' .productsubmit, #foxyshop_product_form_' . $product['id'] . ' #productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");'."\n";
 		echo '});'."\n";
 	}
 	echo '</script>'."\n";

--- a/js/variation.process.jquery.js
+++ b/js/variation.process.jquery.js
@@ -185,19 +185,19 @@ jQuery(document).ready(function($){
 			}
 			if (newcount > 0 && newcount <= newalert) {
 				$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_alert[current_product_id],newcount,inventory_code,$('#fs_name_' + current_product_id).val())).show();
-				$(parentForm + " .productsubmit", parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+				$(parentForm + " .productsubmit, " + parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 			} else if (newcount <= 0) {
 				$(parentForm + " .foxyshop_stock_alert").addClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_none[current_product_id],inventory_match_count,inventory_code,$('#fs_name_' + current_product_id).val())).show();
-				if (!foxyshop_allow_backorder) $(parentForm + " .productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");
+				if (!foxyshop_allow_backorder) $(parentForm + " .productsubmit, " + parentForm + " #productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");
 			} else {
-				$(parentForm + " .productsubmit", parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+				$(parentForm + " .productsubmit, " + parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 				$(parentForm + " .foxyshop_stock_alert").hide();
 			}
 		} else if (typeof arr_foxyshop_inventory[current_product_id] != 'undefined') {
 			if (!foxyshop_allow_backorder) {
 				$("#fs_quantity_max_" + current_product_id).val($("#original_quantity_max_" + current_product_id).val());
 			}
-			$(parentForm + " .productsubmit", parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+			$(parentForm + " .productsubmit, " + parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 			$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").hide();
 		}
 
@@ -228,8 +228,8 @@ jQuery(document).ready(function($){
 		n_sep_by_space = arrl18n_settings[4];
 		new_price += addOnTotal;
 		new_price_original += addOnTotal;
-		$(parentForm + " .foxyshop_main_price .foxyshop_currentprice").text(toCurrency(new_price, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
-		$(parentForm + " .foxyshop_main_price .foxyshop_oldprice").text(toCurrency(new_price_original, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
+		$(parentForm + " .foxyshop_main_price .foxyshop_currentprice, " + parentForm + " #foxyshop_main_price .foxyshop_currentprice").text(toCurrency(new_price, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
+		$(parentForm + " .foxyshop_main_price .foxyshop_oldprice, " + parentForm + " #foxyshop_main_price .foxyshop_oldprice").text(toCurrency(new_price_original, currencySymbol, thousandsSeparator, decimalSeparator, p_precedes, n_sep_by_space));
 
 		//Plugin Function Here - AFTER CHANGE VARIATIONS
 		if (typeof window.foxyshop_after_variation_modifiers == 'function') foxyshop_after_variation_modifiers(new_code, new_codeadd, new_price, new_price_original, new_ikey, current_product_id);
@@ -299,7 +299,7 @@ jQuery(document).ready(function($){
 			e.stopPropagation();
 			e.preventDefault();
 		} else {
-			if (jQuery("#foxyshop_product_form_" + current_product_id + " .productsubmit", "#foxyshop_product_form_" + current_product_id + " #productsubmit").attr("disabled")) return false;
+			if (jQuery("#foxyshop_product_form_" + current_product_id + " .productsubmit, #foxyshop_product_form_" + current_product_id + " #productsubmit").attr("disabled")) return false;
 			return true;
 		}
 

--- a/js/variation.process.jquery.js
+++ b/js/variation.process.jquery.js
@@ -185,19 +185,19 @@ jQuery(document).ready(function($){
 			}
 			if (newcount > 0 && newcount <= newalert) {
 				$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_alert[current_product_id],newcount,inventory_code,$('#fs_name_' + current_product_id).val())).show();
-				$(parentForm + " .productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+				$(parentForm + " .productsubmit", parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 			} else if (newcount <= 0) {
 				$(parentForm + " .foxyshop_stock_alert").addClass("foxyshop_out_of_stock").html(update_inventory_alert_language(arr_foxyshop_inventory_stock_none[current_product_id],inventory_match_count,inventory_code,$('#fs_name_' + current_product_id).val())).show();
 				if (!foxyshop_allow_backorder) $(parentForm + " .productsubmit").attr("disabled","disabled").addClass("foxyshop_disabled");
 			} else {
-				$(parentForm + " .productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+				$(parentForm + " .productsubmit", parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 				$(parentForm + " .foxyshop_stock_alert").hide();
 			}
 		} else if (typeof arr_foxyshop_inventory[current_product_id] != 'undefined') {
 			if (!foxyshop_allow_backorder) {
 				$("#fs_quantity_max_" + current_product_id).val($("#original_quantity_max_" + current_product_id).val());
 			}
-			$(parentForm + " .productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
+			$(parentForm + " .productsubmit", parentForm + " #productsubmit").removeAttr("disabled").removeClass("foxyshop_disabled");
 			$(parentForm + " .foxyshop_stock_alert").removeClass("foxyshop_out_of_stock").hide();
 		}
 
@@ -299,7 +299,7 @@ jQuery(document).ready(function($){
 			e.stopPropagation();
 			e.preventDefault();
 		} else {
-			if (jQuery("#foxyshop_product_form_" + current_product_id + " .productsubmit").attr("disabled")) return false;
+			if (jQuery("#foxyshop_product_form_" + current_product_id + " .productsubmit", "#foxyshop_product_form_" + current_product_id + " #productsubmit").attr("disabled")) return false;
 			return true;
 		}
 


### PR DESCRIPTION
Added selectors that include the old id element for users that have customized themefiles so that inventory will work without needing to update the customized themefiles. Original changes [here](https://github.com/FoxyCart/foxyshop/pull/45/files#diff-ddb5a5c7456b15c787c4a0d1a93d384d899fafd5d6d994341b418ec2edfa7f0fL190-R191).