### PR TITLE
Add id argument for usage of the_title filter hook to prevent plugin conflicts

### DIFF
--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -1297,7 +1297,7 @@ function foxyshop_featured_category($categoryName, $showAddToCart = false, $show
 		if ($product['hide_product']) continue;
 
 		if ($simpleList) {
-			$simplewrite = '<li><a href="' . $product['url'] . '">' . apply_filters('the_title', $product['name']) . '</a></li>'."\n";
+			$simplewrite = '<li><a href="' . $product['url'] . '">' . apply_filters('the_title', $product['name'], $product['id']) . '</a></li>'."\n";
 			echo wp_kses_post(apply_filters("foxyshop_featured_category_simple", $simplewrite, $product));
 		} else {
 			$thumbnailSRC = foxyshop_get_main_image("thumbnail");
@@ -1306,7 +1306,7 @@ function foxyshop_featured_category($categoryName, $showAddToCart = false, $show
 			$write .= '<a href="' . $product['url'] . '"><img src="' . $thumbnailSRC . '" alt="' . $product['name'] . '" class="foxyshop_main_image" /></a>';
 			$write .= "</div>\n";
 			$write .= '<div class="foxyshop_product_info">';
-			$write .= '<h2><a href="' . $product['url'] . '">' . apply_filters('the_title', $product['name']) . '</a></h2>';
+			$write .= '<h2><a href="' . $product['url'] . '">' . apply_filters('the_title', $product['name'], $product['id']) . '</a></h2>';
 			$write .= foxyshop_price(0, 0);
 			if ($showMoreDetails) $write .= '<a href="' . $product['url'] . '" class="foxyshop_button">' . __('More Details') . '</a>';
 			if ($showAddToCart) $write .= '<a href="' . foxyshop_product_link("", true) . '" class="foxyshop_button">' . __('Add To Cart') . '</a>';
@@ -1374,7 +1374,7 @@ function foxyshop_related_products($sectiontitle = "Related Products", $maxprodu
 			$write .= '<a href="' . $product['url'] . '"><img src="' . $thumbnailSRC . '" alt="' . $product['name'] . '" class="foxyshop_main_image" /></a>';
 			$write .= "</div>\n";
 			$write .= '<div class="foxyshop_product_info">';
-			$write .= '<h2><a href="' . $product['url'] . '">' . apply_filters('the_title', $product['name']) . '</a></h2>';
+			$write .= '<h2><a href="' . $product['url'] . '">' . apply_filters('the_title', $product['name'], $product['id']) . '</a></h2>';
 			$write .= foxyshop_price(0,0);
 			$write .= "</div>\n";
 			$write .= '<div class="clr"></div>';

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,7 @@ You can exclude this from being output on specific (or all) pages using the "Ski
 * Significant improvements across the plugin to move some of the legacy code to modern Wordpress standards
 * Renaming of some plugin javascript files
 * Renaming `action_process_option_update()` to `foxyshop_action_process_option_update()` and `action_show_user_profile()` to `foxyshop_action_show_user_profile()`
+* Add id argument for usage of "the_title" filter hook to prevent plugin conflicts
 * Fixed issue preventing product option modifiers from outputting if a custom value was set
 * Removing FOXYSHOP_DOCUMENT_ROOT variable
 * Deprecated: Support for Foxy versions 0.7.2 and older (these are also unsupported versions of Foxy, and should not be in use)
@@ -306,6 +307,7 @@ You can exclude this from being output on specific (or all) pages using the "Ski
 * Significant improvements across the plugin to move some of the legacy code to modern Wordpress standards
 * Renaming of some plugin javascript files
 * Renaming `action_process_option_update()` to `foxyshop_action_process_option_update()` and `action_show_user_profile()` to `foxyshop_action_show_user_profile()`
+* Add id argument for usage of "the_title" filter hook to prevent plugin conflicts
 * Fixed issue preventing product option modifiers from outputting if a custom value was set
 * Removing FOXYSHOP_DOCUMENT_ROOT variable
 * Deprecated: Support for Foxy versions 0.7.2 and older (these are also unsupported versions of Foxy, and should not be in use)

--- a/themefiles/foxyshop-product-loop.php
+++ b/themefiles/foxyshop-product-loop.php
@@ -29,7 +29,7 @@ if (!$product['hide_product']) {
 
 	//Show Main Product Info
 	echo '<div class="foxyshop_product_info">';
-	echo '<h2><a href="' . esc_url($product['url']) . '">' . apply_filters('the_title', $product['name']) . '</a></h2>';
+	echo '<h2><a href="' . esc_url($product['url']) . '">' . apply_filters('the_title', $product['name'], $product['id']) . '</a></h2>';
 
 	//Show a sale tag if the product is on sale
 	//if (foxyshop_is_on_sale()) echo '<p>SALE!</p>';

--- a/themefiles/foxyshop-single-product-shortcode.php
+++ b/themefiles/foxyshop-single-product-shortcode.php
@@ -40,7 +40,7 @@ global $foxyshop_prettyphoto_included;
 
 	//Main Product Information Area
 	echo '<div class="foxyshop_product_info">';
-	echo '<h2>' . apply_filters('the_title', $product['name']) . '</h2>';
+	echo '<h2>' . apply_filters('the_title', $product['name'], $product['id']) . '</h2>';
 
 	//Show a sale tag if the product is on sale
 	//if (foxyshop_is_on_sale()) echo '<p>SALE!</p>';

--- a/themefiles/foxyshop-single-product.php
+++ b/themefiles/foxyshop-single-product.php
@@ -39,7 +39,7 @@ while (have_posts()) : the_post();
 	//Main Product Information Area
 	echo '<div class="foxyshop_product_info">';
 	//edit_post_link('<img src="' . FOXYSHOP_DIR . '/images/editicon.png" alt="Edit Product" width="16" height="16" />','<span class="foxyshop_edit_product">','</span>');
-	echo '<h2>' . apply_filters('the_title', $product['name']) . '</h2>';
+	echo '<h2>' . apply_filters('the_title', $product['name'], $product['id']) . '</h2>';
 
 	//Show a sale tag if the product is on sale
 	//if (foxyshop_is_on_sale()) echo '<p class="sale-product">SALE!</p>';


### PR DESCRIPTION
This is a quick change to include the `$id` argument with the plugin usage of the `the_title` hook filter. It not being present was causing a conflict with the "My Calendar" plugin as discovered by a FoxyShop user, as it was correctly expecting two arguments for that function [as per the documentation](https://developer.wordpress.org/reference/hooks/the_title/). Big thanks to our user for bringing this to our attention.