### PR TITLE
Quick fixes for the new custom HTML filtering

### DIFF
--- a/adminfunctions.php
+++ b/adminfunctions.php
@@ -187,7 +187,6 @@ function foxyshop_load_admin_scripts($hook) {
 
 //Loading in Public scripts and styles
 function foxyshop_load_site_scripts() {
-	wp_enqueue_script( 'foxyshop_js', FOXYSHOP_DIR . '/js/foxyshop.js', ['jquery'], FOXYSHOP_VERSION, true);
 	wp_enqueue_style( 'foxyshop_css', FOXYSHOP_DIR . '/css/foxyshop.css', array(), FOXYSHOP_VERSION);
 }
 

--- a/adminfunctions.php
+++ b/adminfunctions.php
@@ -106,7 +106,7 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 		$foxy_allowedtags = $filtered_tags;
 	}
 
-	// Remove HTML comments, because apparently wp_kses doesn't and outputs them to the page instead
+	// Remove HTML comments, because wp_kses doesn't if it contains HTML and outputs the comment tags to the page instead
 	$data = preg_replace('/<!--(.|\s)*?-->/', '', $data);
 
 	return wp_kses($data, $foxy_allowedtags, ['http', 'https', 'mailto', 'sms', 'tel', 'fax', 'webcal']);

--- a/adminfunctions.php
+++ b/adminfunctions.php
@@ -105,6 +105,10 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 		}
 		$foxy_allowedtags = $filtered_tags;
 	}
+
+	// Remove HTML comments, because apparently wp_kses doesn't and outputs them to the page instead
+	$data = preg_replace('/<!--(.|\s)*?-->/', '', $data);
+
 	return wp_kses($data, $foxy_allowedtags, ['http', 'https', 'mailto', 'sms', 'tel', 'fax', 'webcal']);
 
 }

--- a/adminfunctions.php
+++ b/adminfunctions.php
@@ -71,6 +71,9 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 		],
 		'table' => [
 			'rel' => true
+		],
+		'div' => [
+			'dkey' => true
 		]
 	];
 
@@ -109,8 +112,20 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 	// Remove HTML comments, because wp_kses doesn't if it contains HTML and outputs the comment tags to the page instead
 	$data = preg_replace('/<!--(.|\s)*?-->/', '', $data);
 
-	return wp_kses($data, $foxy_allowedtags, ['http', 'https', 'mailto', 'sms', 'tel', 'fax', 'webcal']);
+	// Allow additional styles for CSS filtering
+	add_filter('safe_style_css', 'foxyshop_alter_safe_style_css', 10, 1 );
+	// Filter the HTML using our customised set of allowed tags
+	$filtered = wp_kses($data, $foxy_allowedtags, ['http', 'https', 'mailto', 'sms', 'tel', 'fax', 'webcal']);
+	// Revert back to default allowed styles
+	remove_filter('safe_style_css', 'foxyshop_alter_safe_style_css', 10);
 
+	return $filtered;
+}
+
+// Allow "display" style to the list of allowed CSS styles
+function foxyshop_alter_safe_style_css( $styles ) {
+    $styles[] = 'display';
+    return $styles;
 }
 
 //Insert jQuery

--- a/foxyshop.php
+++ b/foxyshop.php
@@ -89,6 +89,8 @@ if (is_admin()) {
 //Load FoxyShop Scripts and Styles on Public Site
 } else {
 	add_action('wp_enqueue_scripts', 'foxyshop_load_public_scripts');
+	// Needed for backwards compatibility
+	add_action('init', 'foxyshop_load_site_scripts', 1);
 }
 
 //Setup Wizard

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -25,8 +25,9 @@ function foxyshop_load_public_scripts() {
 	} else {
 		foxyshop_insert_foxycart_files();
 	}
-	// Needed for backwards compatibility
-	add_action('init', 'foxyshop_load_site_scripts', 1);
+
+	wp_enqueue_script( 'foxyshop_js', FOXYSHOP_DIR . '/js/foxyshop.js', ['jquery'], FOXYSHOP_VERSION, true);
+
 	if ($foxyshop_settings['ga']) foxyshop_insert_google_analytics();
 }
 

--- a/helperfunctions.php
+++ b/helperfunctions.php
@@ -25,7 +25,8 @@ function foxyshop_load_public_scripts() {
 	} else {
 		foxyshop_insert_foxycart_files();
 	}
-	foxyshop_load_site_scripts();
+	// Needed for backwards compatibility
+	add_action('init', 'foxyshop_load_site_scripts', 1);
 	if ($foxyshop_settings['ga']) foxyshop_insert_google_analytics();
 }
 


### PR DESCRIPTION
With 4.9 we moved to a custom `wp_kses` function to escape the variables containing HTML when escaping. It turns out `wp_kses` doesn't strip `<!-- -->` HTML comments that is commenting out valid HTML, but rather just encodes them so they're output to the page. If the comment is just text then it is removed.

This uses regex to strip all HTML comments to correct that so it'll remove both `<!-- this is a comment -->` as well as `<!-- <div class="commented-out"></div> -->`

This also adds `display` as an allowed CSS style for HTML filtering, but adding and removing the filter as we call `wp_kses` so it doesn't impact other uses.

Also adding a change to use the `init` hook for adding the plugin CSS because there is [some instructions for using that hook for removing it available online](https://foxy-shop.com/documentation/theme-customization/)