### PR TITLE
Correct response handling for external datafeed processing

### DIFF
--- a/datafeedfunctions.php
+++ b/datafeedfunctions.php
@@ -97,11 +97,11 @@ function foxyshop_run_external_datafeeds($external_datafeeds) {
 			$response = wp_remote_post($feedurl,
 				$args);
 
-		//	$response = trim($response['body']);
+			$response_body = trim(wp_remote_retrieve_body($response));
 
 			//If Error, Send Email and Kill Process
-			if ($response != 'foxy' && $response != 'foxysub') {
-				$error_msg = ( is_wp_error( $response ) ? "Datafeed Processing Error: " . $response->get_error_message() : $response['body']  );
+			if ($response_body != 'foxy' && $response_body != 'foxysub') {
+				$error_msg = strip_tags( is_wp_error( $response ) ? "Datafeed Processing Error: " . $response->get_error_message() : $response_body  );
 				$to_email = get_bloginfo('admin_email');
 				$message = "A FoxyCart datafeed error was encountered at " . date("F j, Y, g:i a") . ".\n\n";
 				$message .= "The feed that failed was $feedurl\n\n";

--- a/themefiles/foxyshop-receipt.php
+++ b/themefiles/foxyshop-receipt.php
@@ -159,8 +159,8 @@ foreach($xml->transactions->transaction as $transaction) {
 				//Show Invoice Address Section
 				echo esc_html($customer_first_name . " " . $customer_last_name) . "<br />";
 				if ((string)$transaction->customer_company) echo esc_html($transaction->customer_company) . "<br />";
-				echo esc_html((string)$transaction->customer_address1 . "<br />");
-				if ((string)$transaction->customer_address2) echo esc_html($transaction->customer_address2 . "<br />");
+				echo esc_html((string)$transaction->customer_address1) . "<br />";
+				if ((string)$transaction->customer_address2) echo esc_html($transaction->customer_address2) . "<br />";
 				echo esc_html((string)$transaction->customer_city . ', ' . (string)$transaction->customer_state . ' ' . (string)$transaction->customer_postal_code) . '<br />';
 				if ($show_country) echo esc_html((string)$transaction->customer_country) . '<br />';
 				echo ("&nbsp;</td>\n\n");


### PR DESCRIPTION
This is a quick fix for an error introduced in 9.4, where the error checking for external datafeeds was always being considered as failed, even if the response was just `foxy` or `foxysub`.

This also includes a small fix to the receipt template used in the orders section of the plugin within the WP admin, where it was escaping some break tags in the address section.