### PR TITLE
FEAT: add search to inventory page

### DIFF
--- a/foxyshop.php
+++ b/foxyshop.php
@@ -5,7 +5,7 @@ Plugin Name: FoxyShop
 Plugin URI: https://www.foxy-shop.com/
 Description: FoxyShop is a full integration for FoxyCart and WordPress, providing a robust shopping cart and inventory management tool.
 Author: SparkWeb Interactive, Inc.
-Version: 4.9.5
+Version: 4.9.6
 Author URI: https://www.foxy-shop.com/
 
 **************************************************************************
@@ -38,7 +38,7 @@ the most out of FoxyShop.
 if (!defined('ABSPATH')) exit();
 
 //Setup Plugin Variables
-define('FOXYSHOP_VERSION', "4.9.5");
+define('FOXYSHOP_VERSION', "4.9.6");
 define('FOXYSHOP_DIR', substr(plugin_dir_url(__FILE__),0, strlen(plugin_dir_url(__FILE__))-1) );
 define('FOXYSHOP_PATH', substr(plugin_dir_path(__FILE__),0, strlen(plugin_dir_path(__FILE__))-1) );
 define('FOXYSHOP_PLUGIN_PATH', plugin_dir_path(__FILE__));

--- a/inventory.php
+++ b/inventory.php
@@ -102,25 +102,24 @@ function foxyshop_inventory_management_page() {
 
 			global $wpdb;
 			$sql = "
-					SELECT p.* 
-					FROM {$wpdb->posts} p
-					LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id AND pm.meta_key = '_code'
-					WHERE p.post_type = 'foxyshop_product'
-					AND p.post_status = 'publish'
-					AND (
-							p.post_title LIKE %s
-							OR pm.meta_value LIKE %s
-					)
-					AND EXISTS (
-							SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = p.ID AND meta_key = '_inventory_levels' AND meta_value != ''
-					)
-					ORDER BY p.ID ASC
+				SELECT p.* 
+				FROM {$wpdb->posts} p
+				LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id AND pm.meta_key = '_code'
+				WHERE p.post_type = 'foxyshop_product'
+				AND p.post_status = 'publish'
+				AND (
+					p.post_title LIKE %s
+					OR pm.meta_value LIKE %s
+				)
+				AND EXISTS (
+					SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = p.ID AND meta_key = '_inventory_levels' AND meta_value != ''
+				)
+				ORDER BY p.ID ASC
 			";
 
 			$prepared_sql = $wpdb->prepare($sql, '%' . $wpdb->esc_like($search_query) . '%', '%' . $wpdb->esc_like($search_query) . '%');
 			$product_list = $wpdb->get_results($prepared_sql);
 
-			// $product_list = get_posts($args);
 			$exported = "ID\tName\tCode\tVariation\tInventory";
 			$i = 0;
 			$alternate = "";
@@ -178,7 +177,7 @@ function foxyshop_inventory_management_page() {
 					echo '</tr>'."\n";
 				}
 			}
-			
+
 			wp_reset_postdata();
 			?>
 			</tbody>

--- a/inventory.php
+++ b/inventory.php
@@ -66,6 +66,13 @@ function foxyshop_inventory_management_page() {
 			) . '</p></div>';
 		?>
 
+		<form method="GET" action="">
+				<input type="hidden" name="post_type" value="foxyshop_product" />
+				<input type="hidden" name="page" value="foxyshop_inventory_management_page" />
+				<input type="text" name="search" placeholder="Search by name or code" value="<?php echo isset($_GET['search']) ? esc_attr($_GET['search']) : ''; ?>" style="min-width: 300px;" />
+				<input type="submit" value="Search" class="button-primary" />
+		</form>
+
 		<table cellpadding="0" cellspacing="0" border="0" class="wp-list-table widefat foxyshop-list-table" id="inventory_level" style="margin-top: 14px;">
 			<thead>
 				<tr>
@@ -91,12 +98,34 @@ function foxyshop_inventory_management_page() {
 			</tfoot>
 			<tbody>
 			<?php
-			$args = array('post_type' => 'foxyshop_product', 'post_status' => 'publish', 'numberposts' => "-1", "orderby" => "id", "order" => "ASC", "meta_key" => "_inventory_levels", "meta_compare" => "!=", "meta_value" => "");
-			$product_list = get_posts($args);
+			$search_query = isset($_GET['search']) ? sanitize_text_field($_GET['search']) : '';
+
+			global $wpdb;
+			$sql = "
+					SELECT p.* 
+					FROM {$wpdb->posts} p
+					LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id AND pm.meta_key = '_code'
+					WHERE p.post_type = 'foxyshop_product'
+					AND p.post_status = 'publish'
+					AND (
+							p.post_title LIKE %s
+							OR pm.meta_value LIKE %s
+					)
+					AND EXISTS (
+							SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = p.ID AND meta_key = '_inventory_levels' AND meta_value != ''
+					)
+					ORDER BY p.ID ASC
+			";
+
+			$prepared_sql = $wpdb->prepare($sql, '%' . $wpdb->esc_like($search_query) . '%', '%' . $wpdb->esc_like($search_query) . '%');
+			$product_list = $wpdb->get_results($prepared_sql);
+
+			// $product_list = get_posts($args);
 			$exported = "ID\tName\tCode\tVariation\tInventory";
 			$i = 0;
 			$alternate = "";
 			foreach ($product_list as $single_product) {
+				setup_postdata($single_product);
 				$product = foxyshop_setup_product($single_product, true);
 				$inventory_levels = get_post_meta($single_product->ID,'_inventory_levels',TRUE);
 				if (!is_array($inventory_levels)) $inventory_levels = array();
@@ -149,6 +178,8 @@ function foxyshop_inventory_management_page() {
 					echo '</tr>'."\n";
 				}
 			}
+			
+			wp_reset_postdata();
 			?>
 			</tbody>
 		</table>

--- a/inventory.php
+++ b/inventory.php
@@ -67,10 +67,10 @@ function foxyshop_inventory_management_page() {
 		?>
 
 		<form method="GET" action="" style="margin-top: 10px;">
-				<input type="hidden" name="post_type" value="foxyshop_product" />
-				<input type="hidden" name="page" value="foxyshop_inventory_management_page" />
-				<input type="text" name="search" placeholder="Search by name or code" value="<?php echo isset($_GET['search']) ? esc_attr($_GET['search']) : ''; ?>" style="min-width: 300px;" />
-				<input type="submit" value="Search" class="button-primary" />
+			<input type="hidden" name="post_type" value="foxyshop_product" />
+			<input type="hidden" name="page" value="foxyshop_inventory_management_page" />
+			<input type="text" name="search" placeholder="Search by name or code" value="<?php echo isset($_GET['search']) ? esc_attr($_GET['search']) : ''; ?>" style="min-width: 300px;" />
+			<input type="submit" value="Search" class="button" />
 		</form>
 
 		<table cellpadding="0" cellspacing="0" border="0" class="wp-list-table widefat foxyshop-list-table" id="inventory_level" style="margin-top: 14px;">

--- a/inventory.php
+++ b/inventory.php
@@ -66,7 +66,7 @@ function foxyshop_inventory_management_page() {
 			) . '</p></div>';
 		?>
 
-		<form method="GET" action="">
+		<form method="GET" action="" style="margin-top: 10px;">
 				<input type="hidden" name="post_type" value="foxyshop_product" />
 				<input type="hidden" name="page" value="foxyshop_inventory_management_page" />
 				<input type="text" name="search" placeholder="Search by name or code" value="<?php echo isset($_GET['search']) ? esc_attr($_GET['search']) : ''; ?>" style="min-width: 300px;" />
@@ -125,6 +125,7 @@ function foxyshop_inventory_management_page() {
 			$alternate = "";
 			foreach ($product_list as $single_product) {
 				setup_postdata($single_product);
+				
 				$product = foxyshop_setup_product($single_product, true);
 				$inventory_levels = get_post_meta($single_product->ID,'_inventory_levels',TRUE);
 				if (!is_array($inventory_levels)) $inventory_levels = array();

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: foxycart, shopping, cart, inventory, management, ecommerce, selling, subsc
 Requires at least: 3.1
 Tested up to: 6.6.1
 Requires PHP: 5.3
-Stable tag: 4.9.5
+Stable tag: 4.9.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 FoxyShop provides a robust shopping cart and inventory management tool for use with FoxyCart's hosted e-commerce solution.
@@ -74,6 +74,10 @@ You can exclude this from being output on specific (or all) pages using the "Ski
 
 
 == Changelog ==
+
+= 4.9.6 =
+
+* Add search feature to inventory plugin page
 
 = 4.9.5 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: foxycart
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2AHG2QMABF8SG
 Tags: foxycart, shopping, cart, inventory, management, ecommerce, selling, subscription, foxy
 Requires at least: 3.1
-Tested up to: 6.6.1
+Tested up to: 6.7.2
 Requires PHP: 5.3
 Stable tag: 4.9.6
 License: GPLv2 or later
@@ -328,6 +328,10 @@ You can exclude this from being output on specific (or all) pages using the "Ski
 
 
 == Upgrade Notice ==
+
+= 4.9.6 =
+
+* Add search feature to inventory plugin page
 
 = 4.9.5 =
 


### PR DESCRIPTION
## Search bar

hi guys! i've added a search bar to the inventory page. By taking a look at older pull requests i took some time to change the plugin version to `4.9.6` and add a changelog to the `readme.txt` file.

the search bar can search by both product name and code, so either one will work.

please let me know if there's anything else i need to change in order for this to work smoothly