### PR TITLE
Update HTML tag sanitisation to ensure all attributes included in kses

### DIFF
--- a/adminfunctions.php
+++ b/adminfunctions.php
@@ -36,7 +36,8 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 			'imagekey' => true,
 			'code' => true,
 			'codeadd' => true,
-			'subfrequency' => true
+			'subfrequency' => true,
+			'maxlength' => true
 		],
 		'select' => [
 			'name' => true,
@@ -49,6 +50,7 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 			'priceset' => true,
 			'pricechange' => true,
 			'displaykey' => true,
+			'dkey' => true,
 			'imagekey' => true,
 			'code' => true,
 			'codeadd' => true,
@@ -61,6 +63,7 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 			'priceset' => true,
 			'pricechange' => true,
 			'displaykey' => true,
+			'dkey' => true,
 			'imagekey' => true,
 			'code' => true,
 			'codeadd' => true,
@@ -1008,3 +1011,4 @@ function foxyshop_manage_attributes_jquery($att_type) {
 <?php
 
 }
+

--- a/adminfunctions.php
+++ b/adminfunctions.php
@@ -63,11 +63,18 @@ function foxy_wp_kses_html($data, $filter_tags = [], $allow_forms = false){
 			'priceset' => true,
 			'pricechange' => true,
 			'displaykey' => true,
-			'dkey' => true,
 			'imagekey' => true,
 			'code' => true,
 			'codeadd' => true,
 			'subfrequency' => true
+		],
+		'textarea' => [
+			'name' => true,
+			'class' => true,
+			'id' => true,
+			'disabled' => true,
+			'style' => true,
+			'dkey' => true
 		],
 		'label' => [
 			'dkey' => true
@@ -1011,4 +1018,5 @@ function foxyshop_manage_attributes_jquery($att_type) {
 <?php
 
 }
+
 

--- a/tools-page.php
+++ b/tools-page.php
@@ -493,7 +493,7 @@ for ($i=1;$i<=$max_variations;$i++) {
 					</div>
 					<div class="foxyshop_field_control">
 						<label for="_variation_textsize2_<?php echo esc_attr($i); ?>"><?php _e('Maximum Chars', 'foxyshop'); ?></label>
-						<input type="text" name="_variation_textsize2_<?php echo esc_attr($i); ?>" id="_variation_textsize2_<?php echo esc_attr($i); ?>" value="<?php if (isset($arrVariationTextSize)) echo esc_url($arrVariationTextSize[1]); ?>" /> <span><?php _e('characters', 'foxyshop'); ?></span>
+						<input type="text" name="_variation_textsize2_<?php echo esc_attr($i); ?>" id="_variation_textsize2_<?php echo esc_attr($i); ?>" value="<?php if (isset($arrVariationTextSize)) echo esc_attr($arrVariationTextSize[1]); ?>" /> <span><?php _e('characters', 'foxyshop'); ?></span>
 					</div>
 					<div style="clear: both;"></div>
 				</div>
@@ -888,3 +888,4 @@ add_action( 'admin_print_footer_scripts', function() use ($var_type_array, $vari
 
 }
 ?>
+


### PR DESCRIPTION
We missed a couple HTML attributes in our `wp_kses()` function that are needed for product variations. This is a quick change to get those added back in.

Also includes a quick fix on the tools page, where the max characters input was using `esc_url` instead of `esc_attr` when outputting the value in the save variation for text inputs.